### PR TITLE
NGINX: fix cache expiration

### DIFF
--- a/ephemeral-npm.lua
+++ b/ephemeral-npm.lua
@@ -22,6 +22,7 @@ function _M.getPackage()
     local uri = ngx.var.uri
     local meta = ngx.shared.npmMeta
     local body = meta:get(uri)
+    local base = ngx.var.scheme .. '://' .. ngx.var.http_host
     -- yep, our own shared memory cache implementation :-/
     if body == nil then
         ngx.var.ephemeralCacheStatus = 'MISS'
@@ -39,17 +40,9 @@ function _M.getPackage()
     else
         ngx.var.ephemeralCacheStatus = 'HIT'
     end
+    body = string.gsub(body, _M.hostPattern, base)
     ngx.header["Content-Length"] = #body
     ngx.print(body)
-end
-
-function _M.filterPackageBody()
-    local npmConfig = ngx.shared.npmConfig
-    local upstream = npmConfig:get('npm_upstream_pattern')
-    -- need to construct URL because we may be proxying http<->https
-    local base = ngx.var.scheme .. '://' .. ngx.var.http_host
-    -- ngx.log(ngx.ERR, "Modifying JSON of " .. ngx.var.uri .. " to replace '" .. upstream .. "' with '" .. base .. "'")
-    ngx.arg[1] = string.gsub(ngx.arg[1], upstream, base)
 end
 
 return _M

--- a/nginx.conf
+++ b/nginx.conf
@@ -63,14 +63,6 @@ http {
             proxy_buffers          32 1m;
             # need to disable encoding in order to be able to process it locally
             proxy_set_header       Accept-Encoding "";
-            # modifying the response body will change the length
-            header_filter_by_lua_block {
-                ngx.header.content_length = nil
-            }
-            body_filter_by_lua_block {
-                local ephemeralNPM = require "ephemeral-npm"
-                ephemeralNPM.filterPackageBody()
-            }
         }
         location @fetch-tgz {
             internal;

--- a/nginx.conf
+++ b/nginx.conf
@@ -22,7 +22,7 @@ http {
     proxy_cache_lock  on;
     log_format upstreamlog '$remote_addr - $remote_user [$time_local] '
                            '"$request" $status $body_bytes_sent '
-                           '"$http_referer" "$http_user_agent" "$upstream_cache_status"';
+                           '"$http_referer" "$http_user_agent" "$ephemeralCacheStatus"';
     access_log logs/access.log upstreamlog;
 
     lua_shared_dict npmConfig 32k;
@@ -44,25 +44,26 @@ http {
             try_files          $uri @fetch-tgz;
         }
         location / {
+            set $ephemeralCacheStatus '-';
+            # We can't do caching at the proxy level because we can't easily
+            # parameterize cache lifetime for proxy_cache. Instead, we do
+            # the caching ourselves in Lua using a shared dict.
             content_by_lua_block {
                 local ephemeralNPM = require "ephemeral-npm"
                 ephemeralNPM.getPackage()
             }
         }
+        # This is just a straight though, uncaching proxy to the upstream
+        # registry.
+        # We have to use a path prefix instead of an internal @name because
+        # we need to be able to make sub-requests using ngx.location.capture()
         location /-@- {
             internal;
             rewrite                /-@-/(.+) /$1 break;
             resolver               127.0.0.1 ipv6=off;
             proxy_pass             $npm_config_registry;
             proxy_buffers          32 1m;
-            proxy_cache            NPM;
-            # need nginx-1.11.10 for this, which isn't in openresty yet:
-            # proxy_cache_background_update on;
-            proxy_cache_revalidate on;
-            # let our metadata be 20 minutes old, at most
-            proxy_cache_valid      200  20m;
-            proxy_cache_use_stale  error timeout invalid_header updating http_500 http_502 http_503 http_504;
-            # need to disable encoding in order to be able to filter the response body
+            # need to disable encoding in order to be able to process it locally
             proxy_set_header       Accept-Encoding "";
             # modifying the response body will change the length
             header_filter_by_lua_block {

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,10 +11,9 @@ events {
 http {
     # We literally only care about 2 types of files/payloads.
     types {
-        application/json                      json;
         application/gzip                      tgz;
     }
-    default_type  application/octet-stream;
+    default_type  application/json;
     sendfile        on;
     keepalive_timeout  65;
     proxy_cache_path  /tmp/npm/cache levels=1:2 keys_zone=NPM:10m inactive=90d max_size=5g;
@@ -32,7 +31,6 @@ http {
         local ephemeralNPM = require "ephemeral-npm"
         ephemeralNPM.init()
     }
-
     server {
         listen       4873;
         set $npm_config_registry '';


### PR DESCRIPTION
As the commits themselves say:
```
nginx: fix non-expiring cache

The shared memory based caching was being done without any form of
expiration. As as iniital step, hard-code the default 5m MAXAGE that is
supposed to be configurable in all ephemeral-npm variants.
```

```
nginx: fix bad Content-Type on package metadata
```

```
nginx: consolidate per-request Lua usage

Instead of invoking Lua at multiple parts of the request lifecycle,
consolidate to as few phases as possible.

As a bonus, this also simplifies the code.
```