### PR TITLE
nginx: add support for MAXAGE env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Ryan Graham <rmg@ca.ibm.com>
 
 RUN apk --no-cache add dnsmasq
 
-ADD entrypoint.sh nginx.conf ephemeral-npm.lua /
+ADD entrypoint.sh nginx.conf ephemeral-npm.lua ephemeral-utils.lua /
 
 # Not port 80 because ephemeral-npm stnadardized on couchdb's port already
 EXPOSE 4873

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --no-cache add dnsmasq
 
 ADD entrypoint.sh nginx.conf ephemeral-npm.lua ephemeral-utils.lua /
 
-# Not port 80 because ephemeral-npm stnadardized on couchdb's port already
+# Not port 80 because ephemeral-npm standardized on couchdb's port already
 EXPOSE 4873
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,13 +4,14 @@
 # [x] npm_config_registry
 # [ ] MAX_BODY_SIZE
 # [ ] MAX_USERS
-# [ ] MAXAGE
+# [x] MAXAGE
 # [ ] TIMEOUT
 # [ ] NPM_SECRET
 # [ ] NPM_USER
 # [ ] NPM_PASSWORD
 
 export npm_config_registry=${npm_config_registry:-https://registry.npmjs.org}
+export MAXAGE=${MAXAGE:-5m}
 
 # necessary because nginx requires a resolver when upstreams are dynamic
 dnsmasq --listen-address=127.0.0.1 --user=root

--- a/ephemeral-npm.lua
+++ b/ephemeral-npm.lua
@@ -1,17 +1,13 @@
 local cjson = require "cjson.safe"
+local utils = require "ephemeral-utils"
 
 local _M = {}
-
-local function parseDuration(str)
-    -- TODO: parse inputs like "1h", "2d", "10m" and return them as seconds
-    return 5 * 60
-end
 
 function _M.init()
     local npmConfig = ngx.shared.npmConfig
     _M.registry = os.getenv("npm_config_registry"):gsub("/+$", "")
     _M.hostPattern = _M.registry:gsub("%.", "%%."):gsub("%-", "%%-")
-    _M.MAXAGE = parseDuration(os.getenv("MAXAGE") or "5m")
+    _M.MAXAGE = utils.parseDuration(os.getenv("MAXAGE") or "5m")
     -- escape . and - which have special meaning in Lua patterns
     npmConfig:set('npm_config_registry', _M.registry)
     npmConfig:set('npm_upstream_pattern', _M.hostPattern)

--- a/ephemeral-utils.lua
+++ b/ephemeral-utils.lua
@@ -1,0 +1,26 @@
+local _Utils = {}
+
+local SECONDS = {
+  s = 1,
+  m = 60,
+  h = 60 * 60,
+  d = 24 * 60 * 60,
+  w = 7 * 24 * 60 * 60,
+  M = 30 * 24 * 60 * 60,
+  y = 365 * 24 * 60 * 60,
+}
+
+function _Utils.parseDuration(str)
+    local total = 0
+    for n,scale in string.gmatch(str, "(%d+)([smhdwMy])") do
+        total = total + n * SECONDS[scale]
+    end
+    return total
+end
+
+assert(_Utils.parseDuration('5m') == 300)
+assert(_Utils.parseDuration('10m') == 600)
+assert(_Utils.parseDuration('1h') == 60 * 60)
+assert(_Utils.parseDuration('1h1m') == 61 * 60)
+
+return _Utils


### PR DESCRIPTION
Supporting the same format as the other versions of ephemeral-npm, which
allows for things like 30s, 5m, 1w1d.