### PR TITLE
Support static seed publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM openresty/openresty:alpine
 MAINTAINER Ryan Graham <rmg@ca.ibm.com>
 
-RUN apk --no-cache add dnsmasq
+RUN apk --no-cache add dnsmasq jq perl curl
 
-ADD entrypoint.sh nginx.conf ephemeral-npm.lua ephemeral-utils.lua /
+ADD entrypoint.sh nginx.conf ephemeral-npm.lua ephemeral-utils.lua preseed.sh /
 
 # Not port 80 because ephemeral-npm standardized on couchdb's port already
 EXPOSE 4873

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,9 @@ export MAXAGE=${MAXAGE:-5m}
 dnsmasq --listen-address=127.0.0.1 --user=root
 
 # in case /tmp/npm hasn't been created as a tmpfs already
-mkdir -p /tmp/npm/{store,temp,cache}
+mkdir -p /tmp/npm/store
+mkdir -p /tmp/npm/temp
+mkdir -p /tmp/npm/cache
 # nginx runs as uid nobody and it needs write access
 chown -R nobody /tmp/npm
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,8 @@
 # [ ] NPM_USER
 # [ ] NPM_PASSWORD
 
+source preseed.sh
+
 export npm_config_registry=${npm_config_registry:-https://registry.npmjs.org}
 export MAXAGE=${MAXAGE:-5m}
 
@@ -20,6 +22,9 @@ dnsmasq --listen-address=127.0.0.1 --user=root
 mkdir -p /tmp/npm/store
 mkdir -p /tmp/npm/temp
 mkdir -p /tmp/npm/cache
+
+maybePreseed
+
 # nginx runs as uid nobody and it needs write access
 chown -R nobody /tmp/npm
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -31,6 +31,7 @@ http {
         local ephemeralNPM = require "ephemeral-npm"
         ephemeralNPM.init()
     }
+
     server {
         listen       4873;
         set $npm_config_registry '';
@@ -58,10 +59,19 @@ http {
         # we need to be able to make sub-requests using ngx.location.capture()
         location /-@- {
             internal;
-            rewrite                /-@-/(.+) /$1 break;
-            resolver               127.0.0.1 ipv6=off;
-            proxy_pass             $npm_config_registry;
-            proxy_buffers          32 1m;
+            rewrite            /-@-/(.+) /$1 break;
+            root               /tmp/npm/store;
+            set                $ephemeralCacheStatus "HIT";
+            try_files          /$1/package.json @fetch-meta;
+        }
+        location @fetch-meta {
+            internal;
+            set                $ephemeralCacheStatus "MISS";
+            resolver           127.0.0.1 ipv6=off;
+            proxy_pass         $npm_config_registry;
+            proxy_buffers      512 512k;
+            proxy_temp_path    /tmp/npm/temp;
+            proxy_buffering    on;
             # need to disable encoding in order to be able to process it locally
             proxy_set_header       Accept-Encoding "";
         }

--- a/preseed.sh
+++ b/preseed.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+function preSeed() {
+  mkdir /tmp/seed
+  tgz=$1
+  tar -xzf $1 -C /tmp/seed
+  shasum=$(shasum $tgz | cut -d' ' -f1)
+  seedJson=/tmp/seed/package/package.json
+  upstreamJson=/tmp/seed/upstream.json
+  pkgName=$(cat $seedJson | jq -r .name)
+  pkgVersion=$(cat $seedJson | jq -r .version)
+  mkdir -p /tmp/npm/store/$pkgName
+
+  cat <<-EOF
+Preseeding with:
+  name: "$pkgName"
+  version: "$pkgVersion"
+  shasum: "$shasum"
+  tag: "latest"
+EOF
+
+  cat > /tmp/seed/seed.jq <<-EOJQ
+  .versions["$pkgVersion"] |= \$seedJson[0]
+  | .versions["$pkgVersion"].dist.shasum = \$shasum
+  | .versions["$pkgVersion"].dist.tarball = "$npm_config_registry/$pkgName/-/$pkgName-$pkgVersion.tgz"
+  | .["dist-tags"].latest = "$pkgVersion"
+EOJQ
+
+  curl -sL $npm_config_registry/$pkgName > $upstreamJson
+  jq --from-file /tmp/seed/seed.jq \
+    --slurpfile seedJson $seedJson \
+    --arg shasum $shasum \
+    --arg pkgName $pkgName \
+    --arg pkgVersion $pkgVersion \
+    $upstreamJson \
+  > /tmp/npm/store/$pkgName/package.json
+  cp $tgz /tmp/npm/store/$pkgName/$pkgName-$pkgVersion.tgz
+}
+
+function maybePreseed() {
+  echo "checking if given a tarball..."
+  cat - > /tmp/maybe.tgz
+  echo "done reading input."
+  if tar -tzf /tmp/maybe.tgz > /dev/null; then
+    preSeed /tmp/maybe.tgz
+  else
+    echo 'no pre-seed package.'
+  fi
+}


### PR DESCRIPTION
Rather than supporting `npm publish`, this feature allows a tarball to be fed as input when the container is started and have that package tarball (and associated metadata) overlayed on top of whatever metadata upstream is providing.

To test some local changes as a patch release:

```sh
$ npm info .dist-tags.latest
1.2.2
$ npm pack
my-package-1.2.3.tgz
$ cat my-package-1.2.3.tgz | docker run -i -p 4873:4873 strongloop/ephemeral-npm:nginx
...
```

elsewhere, in a package that depends on `my-package@1.2.x`

```sh
$ npm install --registry=http://127.0.0.1:4873/
my-app@1.2.2 /Users/ryan/work/my-app
└── my-package@1.2.3
...
```

We can now test unreleased changes as though they had been tested _without_ introducing package linking as a test environment complication.